### PR TITLE
Enter password bug fixed

### DIFF
--- a/infobook.c
+++ b/infobook.c
@@ -318,6 +318,10 @@ void password(void){
 			pass[i]=ch;
 			i++;
 		}
+		else if(ch==8 && i>0) {
+			printf("\b \b");
+			i--;
+		}
     }
 	pass[i]='\0';
 	if(strcmp(pass,passwords)==0){


### PR DESCRIPTION
Bug Description and Fix
Bug:
When the user entered a password and mistakenly typed a wrong character, pressing the Backspace key (ch == 8) did not move the cursor backward and erase the character properly. Instead, the cursor remained in place, leading to incorrect password input behavior.

Fix:
The issue was resolved by adding logic to handle the Backspace key correctly. Now, when the user presses Backspace, the last character is removed from the pass array, and the cursor moves backward visually using \b \b. This ensures that users can correct their password input properly.

Fixed Code Snippet:
in password function
=============================================================================
else if(ch == 8 && i > 0) {
    printf("\b \b");  // Move cursor back, erase character, and move back again
    i--;  // Decrease index to remove the last entered character
}
Now, the Backspace key behaves as expected, allowing users to erase incorrect characters while entering the password.

==============================================================================